### PR TITLE
feat: Add NetBird template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    target-branch: "dev"

--- a/.github/workflows/dev-template-prerelease.yml
+++ b/.github/workflows/dev-template-prerelease.yml
@@ -1,0 +1,148 @@
+name: Dev Template Pre-release
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  package-and-publish:
+    name: Package templates and publish dev pre-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: dev-template-prerelease
+      cancel-in-progress: true
+    env:
+      RELEASE_TAG: dev
+      RELEASE_NAME: Templates dev pre-release
+      RELEASE_DIR: release-assets
+      ARCHIVE_NAME: templates-dev.zip
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Package templates into a single zip archive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_dir="${RELEASE_DIR}"
+          templates_root="templates"
+          archive_name="${ARCHIVE_NAME}"
+          zip_path="${release_dir}/${archive_name}"
+
+          mkdir -p "${release_dir}"
+
+          if [[ ! -d "${templates_root}" ]]; then
+            echo "::error::Templates directory not found at ${templates_root}"
+            exit 1
+          fi
+
+          if ! command -v zip >/dev/null 2>&1; then
+            echo "::error::zip command not available on runner"
+            exit 1
+          fi
+
+          mapfile -t templates < <(find "${templates_root}" -mindepth 1 -maxdepth 1 -type d -printf '%P\n' | sort)
+
+          if [[ ${#templates[@]} -eq 0 ]]; then
+            echo "::error::No template directories found under ${templates_root}"
+            exit 1
+          fi
+
+          rm -f "${zip_path}"
+          echo "Creating combined archive ${zip_path} containing ${#templates[@]} template directories"
+          (
+            cd "${templates_root}"
+            shopt -s dotglob
+            zip -r -9 "../${zip_path}" -- ./*
+          )
+
+          if [[ ! -f "${zip_path}" ]]; then
+            echo "::error::Archive was not created at ${zip_path}"
+            exit 1
+          fi
+
+      - name: Build release notes
+        id: prepare-release-notes
+        shell: bash
+        env:
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          notes="Automated pre-release from the dev branch.\n\n"
+          notes+="- Branch: dev\n"
+          notes+="- Commit: ${CURRENT_SHA}\n"
+
+          changelog_path="CHANGELOG.md"
+          unreleased_section=""
+
+          if [[ -f "${changelog_path}" ]]; then
+            unreleased_section=$(
+              awk '
+                BEGIN { capture = 0 }
+                /^##[[:space:]]+Unreleased[[:space:]]*$/ {
+                  capture = 1
+                  print
+                  next
+                }
+                /^##[[:space:]]+/ {
+                  if (capture) {
+                    exit
+                  }
+                }
+                capture { print }
+              ' "${changelog_path}"
+            )
+          fi
+
+          if [[ -n "${unreleased_section//[[:space:]]/}" ]]; then
+            notes+="\n${unreleased_section}\n"
+          fi
+
+          {
+            echo "resolved_release_notes<<EOF"
+            printf '%b\n' "${notes}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Move dev tag to current commit
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "${RELEASE_TAG}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${RELEASE_TAG}" --force
+
+      - name: Delete existing dev release (if any)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release delete "${RELEASE_TAG}" --yes
+          fi
+
+      - name: Create or update GitHub pre-release and upload assets
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ env.RELEASE_NAME }}
+          body: ${{ steps.prepare-release-notes.outputs.resolved_release_notes }}
+          draft: false
+          prerelease: true
+          make_latest: false
+          overwrite_files: true
+          files: ${{ env.RELEASE_DIR }}/${{ env.ARCHIVE_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ manual releases can pull details straight from this file.
 
 ## Unreleased
 
-- Nothing yet.
+- [@github-handle] Add a NetBird template with reverse proxy, gRPC, and ModSecurity defaults.
+
+## Templates release v0.2 - 2026-02-20
+
+- [@TheophileDiot] Align Jellyfin reverse proxy config with official docs (ModSec, rate limit, CSP, Permissions-Policy) + fix issues with the CRS
 
 ## Templates release v0.1 - 2025-11-03
 

--- a/README.md
+++ b/README.md
@@ -62,17 +62,18 @@ This repository packages those JSON definitions alongside their configuration sn
 | [Drupal](templates/drupal/)       | Secure template with CMS-aware defaults               | `templates/drupal/`    |
 | [Jellyfin](templates/jellyfin/)   | Media streaming template with reverse proxy tuning    | `templates/jellyfin/`  |
 | [Nextcloud](templates/nextcloud/) | Secure template with WebDAV-aware defaults            | `templates/nextcloud/` |
+| [NetBird](templates/netbird/)     | Self-hosted template with gRPC and websocket routing  | `templates/netbird/`   |
 | [Tomcat](templates/tomcat/)       | Reverse proxy template with servlet-friendly defaults | `templates/tomcat/`    |
 | [WordPress](templates/wordpress/) | Secure template with essential hardening defaults     | `templates/wordpress/` |
 
 ```text
 templates/
-├── wordpress/
+├── netbird/
 │   ├── template.json
 │   └── configs/
 │       └── modsec/
-│           └── wordpress_false_positives.conf
-└── plex/
+│           └── netbird_false_positives.conf
+└── wordpress/
     └── template.json
 ```
 

--- a/templates/netbird/README.md
+++ b/templates/netbird/README.md
@@ -1,0 +1,57 @@
+# NetBird Template
+
+## Overview
+
+Provision a BunkerWeb configuration tailored for a self-hosted NetBird stack.
+The template wires relay, websocket, REST API, OAuth2, and gRPC endpoints with
+long-lived timeout defaults suited for control-plane traffic.
+
+## Prerequisites
+
+- BunkerWeb `>= 1.6.9~rc1` (gRPC proxy settings used by this template were
+  introduced in that release line).
+- A reachable `netbird-server` upstream for relay, API, OAuth2, and gRPC
+  routes.
+- A reachable `netbird-dashboard` upstream for the fallback `/` route.
+- Access to the BunkerWeb UI or multisite environment variables.
+
+## Files
+
+- `template.json` - Template definition with guided steps for TLS, proxy, and
+  gRPC settings.
+- `configs/modsec/netbird_false_positives.conf` - CRS exclusions for known
+  NetBird OAuth2 false positives.
+
+## Setup
+
+1. **Import the template**
+   - *UI import (recommended)*: open the BunkerWeb `Templates` page, click
+     **Create new template**, switch to **Raw** mode, paste `template.json`,
+     and save.
+   - *Plugin bundle*: copy `netbird/` into your BunkerWeb plugin
+     `templates/` directory.
+2. **Assign the template** to your NetBird site (`USE_TEMPLATE=netbird` or
+   select it in the UI).
+3. **Adjust domains and TLS** so `SERVER_NAME` and certificate options match
+   your deployment.
+4. **Confirm upstreams** by updating `REVERSE_PROXY_HOST*`, `GRPC_HOST*`, and
+   `REVERSE_PROXY_HOST_999` if your service names or ports differ.
+5. **Reload BunkerWeb** and verify dashboard access, OAuth2 flows, relay
+   traffic, and websocket connectivity.
+
+## Customization Tips
+
+- Keep `REVERSE_PROXY_WS=yes` and `REVERSE_PROXY_WS_1=yes` for relay and
+  websocket routes.
+- If you run NetBird on non-default ports, update both HTTP and gRPC upstream
+  hosts together.
+- Lower `LIMIT_REQ_RATE` or `LIMIT_CONN_MAX_HTTP*` only after confirming your
+  expected number of peers and API clients.
+- Adjust `configs/modsec/netbird_false_positives.conf` if CRS rule IDs change
+  in your deployment.
+
+## Validation
+
+- Run `jq . template.json` to verify JSON syntax.
+- Test `/relay`, `/ws-proxy/`, `/api/`, `/oauth2/`, and dashboard `/` through
+  BunkerWeb to confirm routing and timeout behavior.

--- a/templates/netbird/configs/modsec/netbird_false_positives.conf
+++ b/templates/netbird/configs/modsec/netbird_false_positives.conf
@@ -1,0 +1,3 @@
+# NetBird OAuth2 endpoints can trigger CRS SQLi false positives.
+SecRule REQUEST_FILENAME "/oauth2/auth" "id:3000000,ctl:ruleRemoveById=931100,ctl:ruleRemoveById=934110,nolog"
+SecRule REQUEST_FILENAME "/oauth2/token" "id:3000001,ctl:ruleRemoveById=931100,ctl:ruleRemoveById=934110,nolog"

--- a/templates/netbird/template.json
+++ b/templates/netbird/template.json
@@ -1,0 +1,136 @@
+{
+  "id": "netbird",
+  "name": "NetBird self-hosted template with gRPC and websocket routing",
+  "settings": {
+    "SERVER_NAME": "netbird.example.com",
+    "AUTO_LETS_ENCRYPT": "yes",
+    "USE_LETS_ENCRYPT_STAGING": "no",
+    "USE_LETS_ENCRYPT_WILDCARD": "no",
+    "LETS_ENCRYPT_CHALLENGE": "http",
+    "LETS_ENCRYPT_DNS_PROVIDER": "",
+    "LETS_ENCRYPT_DNS_PROPAGATION": "default",
+    "LETS_ENCRYPT_DNS_CREDENTIAL_ITEM": "",
+    "USE_CUSTOM_SSL": "no",
+    "CUSTOM_SSL_CERT_PRIORITY": "file",
+    "CUSTOM_SSL_CERT": "",
+    "CUSTOM_SSL_KEY": "",
+    "CUSTOM_SSL_CERT_DATA": "",
+    "CUSTOM_SSL_KEY_DATA": "",
+    "ALLOWED_METHODS": "GET|POST|HEAD|OPTIONS|PUT|DELETE|PATCH",
+    "USE_LIMIT_REQ": "yes",
+    "LIMIT_REQ_RATE": "15r/s",
+    "LIMIT_CONN_MAX_HTTP1": "30",
+    "LIMIT_CONN_MAX_HTTP2": "200",
+    "LIMIT_CONN_MAX_HTTP3": "200",
+    "USE_REVERSE_PROXY": "yes",
+    "REVERSE_PROXY_INTERCEPT_ERRORS": "no",
+    "REVERSE_PROXY_URL": "/relay",
+    "REVERSE_PROXY_HOST": "http://netbird-server",
+    "REVERSE_PROXY_WS": "yes",
+    "REVERSE_PROXY_READ_TIMEOUT": "1d",
+    "REVERSE_PROXY_URL_1": "/ws-proxy/",
+    "REVERSE_PROXY_HOST_1": "http://netbird-server",
+    "REVERSE_PROXY_WS_1": "yes",
+    "REVERSE_PROXY_READ_TIMEOUT_1": "1d",
+    "REVERSE_PROXY_URL_2": "/api/",
+    "REVERSE_PROXY_HOST_2": "http://netbird-server",
+    "REVERSE_PROXY_URL_3": "/oauth2/",
+    "REVERSE_PROXY_HOST_3": "http://netbird-server",
+    "REVERSE_PROXY_READ_TIMEOUT_3": "1d",
+    "USE_GRPC": "yes",
+    "GRPC_URL": "/signalexchange.SignalExchange/",
+    "GRPC_HOST": "grpc://netbird-server:80",
+    "GRPC_SOCKET_KEEPALIVE": "on",
+    "GRPC_READ_TIMEOUT": "1d",
+    "GRPC_SEND_TIMEOUT": "1d",
+    "GRPC_URL_1": "/management.ManagementService/",
+    "GRPC_HOST_1": "grpc://netbird-server:80",
+    "GRPC_SOCKET_KEEPALIVE_1": "on",
+    "GRPC_READ_TIMEOUT_1": "1d",
+    "GRPC_SEND_TIMEOUT_1": "1d",
+    "REVERSE_PROXY_URL_999": "/",
+    "REVERSE_PROXY_HOST_999": "http://netbird-dashboard"
+  },
+  "configs": ["modsec/netbird_false_positives.conf"],
+  "steps": [
+    {
+      "title": "Step 1 - Domain and HTTPS",
+      "subtitle": "Choose the public NetBird domain and how TLS certificates are managed.",
+      "settings": [
+        "SERVER_NAME",
+        "AUTO_LETS_ENCRYPT",
+        "USE_LETS_ENCRYPT_STAGING",
+        "USE_LETS_ENCRYPT_WILDCARD",
+        "LETS_ENCRYPT_CHALLENGE",
+        "LETS_ENCRYPT_DNS_PROVIDER",
+        "LETS_ENCRYPT_DNS_PROPAGATION",
+        "LETS_ENCRYPT_DNS_CREDENTIAL_ITEM",
+        "USE_CUSTOM_SSL",
+        "CUSTOM_SSL_CERT_PRIORITY",
+        "CUSTOM_SSL_CERT",
+        "CUSTOM_SSL_KEY",
+        "CUSTOM_SSL_CERT_DATA",
+        "CUSTOM_SSL_KEY_DATA"
+      ]
+    },
+    {
+      "title": "Step 2 - Backend services",
+      "subtitle": "Set where BunkerWeb reaches your NetBird server and dashboard backends.",
+      "settings": [
+        "USE_REVERSE_PROXY",
+        "USE_GRPC",
+        "REVERSE_PROXY_INTERCEPT_ERRORS",
+        "REVERSE_PROXY_HOST",
+        "REVERSE_PROXY_HOST_1",
+        "REVERSE_PROXY_HOST_2",
+        "REVERSE_PROXY_HOST_3",
+        "GRPC_HOST",
+        "GRPC_HOST_1",
+        "REVERSE_PROXY_HOST_999"
+      ]
+    },
+    {
+      "title": "Step 3 - HTTP and websocket routes",
+      "subtitle": "Map relay, websocket, API, OAuth2, and dashboard paths to the right upstream.",
+      "settings": [
+        "REVERSE_PROXY_URL",
+        "REVERSE_PROXY_WS",
+        "REVERSE_PROXY_URL_1",
+        "REVERSE_PROXY_WS_1",
+        "REVERSE_PROXY_URL_2",
+        "REVERSE_PROXY_URL_3",
+        "REVERSE_PROXY_URL_999"
+      ]
+    },
+    {
+      "title": "Step 4 - gRPC and long-lived connections",
+      "subtitle": "Configure gRPC method prefixes plus keepalive and timeout values for persistent sessions.",
+      "settings": [
+        "GRPC_URL",
+        "GRPC_URL_1",
+        "GRPC_SOCKET_KEEPALIVE",
+        "GRPC_SOCKET_KEEPALIVE_1",
+        "GRPC_READ_TIMEOUT",
+        "GRPC_SEND_TIMEOUT",
+        "GRPC_READ_TIMEOUT_1",
+        "GRPC_SEND_TIMEOUT_1",
+        "REVERSE_PROXY_READ_TIMEOUT",
+        "REVERSE_PROXY_READ_TIMEOUT_1",
+        "REVERSE_PROXY_READ_TIMEOUT_3"
+      ]
+    },
+    {
+      "title": "Step 5 - Request limits and ModSecurity",
+      "subtitle": "Tune allowed methods and request/connection limits, and keep OAuth2 CRS exclusions.",
+      "settings": [
+        "ALLOWED_METHODS",
+        "USE_LIMIT_REQ",
+        "LIMIT_REQ_RATE",
+        "LIMIT_CONN_MAX_HTTP1",
+        "LIMIT_CONN_MAX_HTTP2",
+        "LIMIT_CONN_MAX_HTTP3"
+      ],
+      "configs": ["modsec/netbird_false_positives.conf"]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

* Added a new **NetBird** template (`templates/netbird/`) for self-hosted deployments, including **reverse proxy + websocket routing** and **gRPC method-prefix routing** with long-lived timeout defaults.
* Included a NetBird-specific **ModSecurity CRS false-positive exclusion** config for OAuth2 endpoints (`configs/modsec/netbird_false_positives.conf`).
* Updated repo docs to surface the new template:

  * `CHANGELOG.md`: added an Unreleased entry for the NetBird template.
  * Root `README.md`: added NetBird to the templates list/table and directory tree.

# Testing

* [x] `jq . templates/netbird/template.json`
* [x] Validated template or docs using the listed commands
* [ ] Other (add details below)

<details>
<summary>Validation details</summary>

* JSON validation:

  * `jq . templates/netbird/template.json`

* Sanity checks (from template docs):

  * Import template via **BunkerWeb UI** (Templates → Create new template → Raw → paste `template.json`) or via **plugin bundle** (copy `netbird/` under plugin `templates/`).
  * Route checks (expect correct upstream + long-lived behavior):

    * `GET /relay`
    * `GET /ws-proxy/` (websocket upgrade)
    * `GET /api/`
    * `GET /oauth2/` and `/oauth2/token`
    * `GET /` (dashboard fallback)
  * Confirm gRPC routing works for:

    * `/signalexchange.SignalExchange/`
    * `/management.ManagementService/`

</details>

# Checklist

* [x] I installed the pre-commit hooks and ran `pre-commit run --all-files`.
* [x] I described the service or scenario this change targets.
* [x] `template.json` references only files shipped in the same template directory.
* [x] Template docs note how to import it (plugin bundle and/or web UI upload).
* [x] I updated configs, screenshots, or notes impacted by this change.
* [x] I linked related issues or discussions and added context for reviewers.
