### PR TITLE
feat: Add Xen Orchestra template and maintainers section

### DIFF
--- a/.github/workflows/dev-template-prerelease.yml
+++ b/.github/workflows/dev-template-prerelease.yml
@@ -133,7 +133,7 @@ jobs:
           fi
 
       - name: Create or update GitHub pre-release and upload assets
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/dev-template-prerelease.yml
+++ b/.github/workflows/dev-template-prerelease.yml
@@ -21,7 +21,7 @@ jobs:
       ARCHIVE_NAME: templates-dev.zip
     steps:
       - name: Check out repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/manual-template-release.yml
+++ b/.github/workflows/manual-template-release.yml
@@ -130,7 +130,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Create GitHub release and upload assets
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ inputs.tag }}
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/manual-template-release.yml
+++ b/.github/workflows/manual-template-release.yml
@@ -33,7 +33,7 @@ jobs:
       RESOLVED_RELEASE_NAME: ${{ inputs.release_name != '' && inputs.release_name || format('Templates release {0}', inputs.tag) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ manual releases can pull details straight from this file.
 
 ## Unreleased
 
+## Templates release v0.3 - 2026-02-25
+
+- [@github-handle] Add an automated `dev` pre-release workflow that packages templates on every push to the `dev` branch and replaces any existing dev release.
 - [@github-handle] Add a NetBird template with reverse proxy, gRPC, and ModSecurity defaults.
 
 ## Templates release v0.2 - 2026-02-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ manual releases can pull details straight from this file.
 
 ## Unreleased
 
+- [@github-handle] Add Xen Orchestra template with reverse proxy, WebSocket, and rate limiting defaults.
+
 ## Templates release v0.3 - 2026-02-25
 
 - [@github-handle] Add an automated `dev` pre-release workflow that packages templates on every push to the `dev` branch and replaces any existing dev release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Community-curated collection of ready-to-import BunkerWeb security templates for popular services (WordPress, Drupal, Nextcloud, Jellyfin, Tomcat, NetBird). Each template bundles reverse proxy, TLS, rate limiting, and ModSecurity configurations. GPL-3.0 licensed.
+
+## Development Commands
+
+```bash
+pre-commit install                        # Register git hooks (one-time setup)
+pre-commit run --all-files                # Run full validation suite (Prettier, Codespell, Gitleaks)
+jq . templates/<name>/template.json       # Validate template JSON syntax
+```
+
+No build step or automated test harness exists. Validation is manual: `docker compose config`, `kubectl apply --server-dry-run -f`, or `nginx -t -c <config>` for service-specific checks.
+
+## Repository Architecture
+
+**Template structure** — each template follows this layout:
+
+```
+templates/<service-name>/
+├── template.json                    # BunkerWeb template definition (required)
+├── README.md                        # Service-specific docs
+└── configs/                         # Optional NGINX/ModSecurity snippets
+    └── modsec/
+        └── <service>_false_positives.conf
+```
+
+**template.json schema**:
+
+- `id`: lowercase hyphenated identifier
+- `name`: user-facing label
+- `settings`: BunkerWeb multisite settings as key-value pairs (keys must match BunkerWeb setting names exactly)
+- `configs`: array of relative paths to NGINX config files
+- `steps`: ordered workflow steps with `title`, `subtitle`, `settings`, and `configs` for guided UI import
+
+Use `templates/wordpress/` as the reference template for structure, tone, and step organization.
+
+**CI/CD** — two GitHub Actions workflows:
+
+- `dev-template-prerelease.yml`: auto-packages templates on push to `dev` branch
+- `manual-template-release.yml`: workflow dispatch for production releases
+
+## Conventions
+
+- Directory names: lowercase-kebab-case, ASCII only
+- JSON: two-space indent, double-quoted keys, no trailing commas (Prettier-enforced)
+- Commits: imperative mood ("Add Jellyfin template"), single concern per commit
+- Changelog: all changes go under `## Unreleased` in `CHANGELOG.md` as `- [@github-handle] Summary`
+- Config file naming: `<service>_false_positives.conf` for ModSecurity exclusion rules
+- All config paths in `template.json` are relative to the template root; referenced files must exist in-repo
+- NGINX snippets should include comments when relaxing security defaults
+
+## Git Workflow
+
+- Main branch: `main` (releases), development branch: `dev` (auto pre-releases)
+- Feature branches: `feature/<name>`, bugfix branches: `bugfix/<name>`
+- PRs target `main` with validation notes and linked issues
+- Pre-commit suite must pass before opening PRs
+
+## External References
+
+- [BunkerWeb templates documentation](https://docs.bunkerweb.io/latest/concepts/#templates)
+- `TEMPLATE_GUIDE.md` for detailed template authoring specification
+- `CONTRIBUTING.md` for full contribution workflow

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repository packages those JSON definitions alongside their configuration sn
 - [Repository Layout](#repository-layout)
 - [Contributing](#contributing)
 - [Community](#community)
+- [Maintainers](#maintainers)
 - [License](#license)
 
 ## Getting Started
@@ -165,6 +166,13 @@ Questions or ideas? Join the conversation with fellow BunkerWeb maintainers and 
 - Discord: [discord.gg/YEdMKqztMZ](https://discord.gg/YEdMKqztMZ)
 - GitHub Issues: Use the issue tracker to report bugs or request new templates.
 - Code of Conduct: Review our [community guidelines](CODE_OF_CONDUCT.md) before engaging.
+
+## Maintainers
+
+| Name           | GitHub                                             |
+| -------------- | -------------------------------------------------- |
+| Théophile Diot | [@TheophileDiot](https://github.com/TheophileDiot) |
+| Alexandre      | [@YouKyi](https://github.com/YouKyi)               |
 
 ## License
 

--- a/TEMPLATE_CATALOG.md
+++ b/TEMPLATE_CATALOG.md
@@ -1,0 +1,31 @@
+Production-ready examples with guided steps and optional CRS tuning.
+
+- WordPress
+  - Path: [templates/wordpress/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/wordpress/)
+  - Focus: TLS automation, reverse proxy, rate limits, crawler whitelist, CRS exclusions.
+
+- Nextcloud
+  - Path: [templates/nextcloud/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/nextcloud/)
+  - Focus: Large uploads, WebDAV verbs, caching, CRS Nextcloud exclusions.
+
+- Jellyfin
+  - Path: [templates/jellyfin/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/jellyfin/)
+  - Focus: Streaming timeouts, websockets, buffering, headers, CRS tuning.
+
+- Tomcat
+  - Path: [templates/tomcat/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/tomcat/)
+  - Focus: Reverse proxy, methods, payload sizing, client optimization.
+
+- Drupal
+  - Path: [templates/drupal/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/drupal/)
+  - Focus: TLS defaults, reverse proxy, installer rate limiting, CRS exclusions.
+
+- NetBird
+  - Path: [templates/netbird/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/netbird/)
+  - Focus: gRPC + websocket routing, long-lived connection timeouts, relay/API/OAuth2 path mapping, request limits, CRS OAuth2 exclusions.
+
+- Xen Orchestra
+  - Path: [templates/xen-orchestra/](https://github.com/bunkerity/bunkerweb-templates/tree/main/templates/xen-orchestra/)
+  - Focus: WebSocket support, self-signed upstream, JSON-RPC rate limiting, CRS exclusions.
+
+Tip: Open `template.json` and any `configs/` snippets in each directory for details.

--- a/templates/xen-orchestra/README.md
+++ b/templates/xen-orchestra/README.md
@@ -1,0 +1,67 @@
+# Xen Orchestra Template
+
+## Overview
+
+Provision a BunkerWeb configuration tailored for Xen Orchestra so HTTPS
+automation, reverse proxy, WebSocket upgrades, and JSON-RPC rate limiting work
+out of the box. Bad behavior detection is disabled to avoid false positives
+caused by XO's frequent API polling.
+
+## Prerequisites
+
+- A Xen Orchestra backend reachable from the BunkerWeb instance (typically
+  HTTPS with a self-signed certificate).
+- Access to the BunkerWeb UI or environment variables to assign template
+  settings.
+- Confirm XO listens on HTTPS and that `REVERSE_PROXY_SSL_SNI` is set to `no`
+  when using a self-signed upstream certificate.
+
+## Files
+
+- `template.json` – Template definition with steps for TLS, reverse proxy,
+  rate limiting, and security tuning.
+- `configs/modsec/xen-orchestra_false_positives.conf` – CRS exclusions for
+  the `/jsonrpc` endpoint to prevent false positives from JSON-RPC API traffic.
+
+## Setup
+
+1. **Import the template**
+   - *UI import (recommended)*: open the BunkerWeb `Templates` page, click
+     **Create new template**, switch to **Raw** mode, paste the contents of
+     `template.json`, and save.
+   - *Plugin bundle*: copy `xen-orchestra/` into your BunkerWeb plugin
+     `templates/` directory.
+2. **Assign the template** to the site serving Xen Orchestra
+   (`USE_TEMPLATE=xen-orchestra` or choose it in the UI).
+3. **Adjust TLS automation** so `SERVER_NAME` and certificate options reflect
+   the domain you expose.
+4. **Update upstream target**: point `REVERSE_PROXY_HOST` to your Xen Orchestra
+   instance (e.g. `https://192.168.1.1`) and confirm connectivity from
+   BunkerWeb.
+5. **Review rate limits**: the `/jsonrpc` endpoint is given a higher rate
+   (`15r/s`) to accommodate XO's API polling; adjust if needed.
+6. **Reload BunkerWeb** and log into Xen Orchestra to verify dashboard access,
+   VM console websockets, and live migration actions work through the proxy.
+
+## Customization Tips
+
+- Raise or lower `MAX_CLIENT_SIZE` depending on whether you transfer ISOs or
+  large files through the proxy.
+- Adjust `LIMIT_REQ_RATE_1` for `/jsonrpc` if you have many concurrent users
+  or heavy automation scripts hitting the API.
+- `USE_BAD_BEHAVIOR` is set to `no` because XO's polling pattern triggers false
+  positives; re-enable only after confirming it does not block legitimate
+  traffic.
+- Modify `CONTENT_SECURITY_POLICY` and `PERMISSIONS_POLICY` if you embed XO in
+  an iframe or need additional origins.
+- Set `REVERSE_PROXY_SSL_SNI` to `yes` if your upstream uses a valid
+  certificate matching the hostname.
+- Edit `configs/modsec/xen-orchestra_false_positives.conf` if future CRS
+  updates require different rule IDs.
+
+## Validation
+
+- Run `jq . template.json` to ensure the definition is valid JSON.
+- Test a dashboard login, VM console session (websocket), and a live migration
+  or snapshot action through BunkerWeb to confirm proxying, rate limits, and
+  security settings behave as expected.

--- a/templates/xen-orchestra/configs/modsec/xen-orchestra_false_positives.conf
+++ b/templates/xen-orchestra/configs/modsec/xen-orchestra_false_positives.conf
@@ -1,0 +1,6 @@
+# Xen Orchestra tuning for ModSecurity CRS
+
+# /jsonrpc endpoint: Complex JSON-RPC bodies with VM configs, storage metadata,
+# and network parameters contain special characters that trigger SQLi detection.
+# Method names like vm.start or pool.listAll resemble SQL function calls.
+SecRule REQUEST_URI "@beginsWith /jsonrpc" "id:9010000,phase:2,pass,nolog,ctl:ruleRemoveTargetById=941130;ctl:ruleRemoveTargetById=942200;ctl:ruleRemoveTargetById=942440;ctl:ruleRemoveTargetById=942450"

--- a/templates/xen-orchestra/template.json
+++ b/templates/xen-orchestra/template.json
@@ -1,0 +1,117 @@
+{
+  "id": "xen-orchestra",
+  "name": "Xen Orchestra reverse proxy with WebSocket support",
+  "configs": ["modsec/xen-orchestra_false_positives.conf"],
+  "settings": {
+    "SERVER_NAME": "xo.example.com",
+    "USE_REVERSE_PROXY": "yes",
+    "REVERSE_PROXY_URL": "/",
+    "REVERSE_PROXY_HOST": "https://192.168.1.1",
+    "REVERSE_PROXY_WS": "yes",
+    "REVERSE_PROXY_SSL_SNI": "no",
+    "REVERSE_PROXY_KEEPALIVE": "no",
+    "AUTO_LETS_ENCRYPT": "yes",
+    "USE_LETS_ENCRYPT_STAGING": "no",
+    "USE_LETS_ENCRYPT_WILDCARD": "no",
+    "LETS_ENCRYPT_SERVER": "letsencrypt",
+    "LETS_ENCRYPT_CHALLENGE": "http",
+    "GENERATE_SELF_SIGNED_SSL": "no",
+    "USE_CUSTOM_SSL": "no",
+    "HTTP2": "yes",
+    "HTTP3": "yes",
+    "SSL_PROTOCOLS": "TLSv1.2 TLSv1.3",
+    "MAX_CLIENT_SIZE": "100m",
+    "ALLOWED_METHODS": "GET|POST|HEAD|OPTIONS|PUT|DELETE|PATCH",
+    "USE_GZIP": "yes",
+    "GZIP_PROXIED": "expired no-cache no-store private auth",
+    "USE_BAD_BEHAVIOR": "no",
+    "USE_ANTIBOT": "no",
+    "USE_BLACKLIST": "yes",
+    "USE_DNSBL": "no",
+    "USE_MODSECURITY": "yes",
+    "USE_MODSECURITY_CRS": "yes",
+    "SECURITY_MODE": "block",
+    "LIMIT_REQ_RATE": "6r/s",
+    "LIMIT_REQ_URL_1": "/jsonrpc",
+    "LIMIT_REQ_RATE_1": "15r/s",
+    "LIMIT_CONN_MAX_HTTP1": "50",
+    "LIMIT_CONN_MAX_HTTP2": "200",
+    "LIMIT_CONN_MAX_HTTP3": "200",
+    "KEEP_UPSTREAM_HEADERS": "*",
+    "REFERRER_POLICY": "no-referrer-when-downgrade",
+    "CONTENT_SECURITY_POLICY": "",
+    "PERMISSIONS_POLICY": "",
+    "COOKIE_FLAGS": "* SameSite=Lax",
+    "INTERCEPTED_ERROR_CODES": "400 401 403 404 405 429 500 502 503 504"
+  },
+  "steps": [
+    {
+      "title": "Front service",
+      "subtitle": "Configure the public-facing hostname and TLS settings for Xen Orchestra",
+      "settings": [
+        "SERVER_NAME",
+        "AUTO_LETS_ENCRYPT",
+        "USE_LETS_ENCRYPT_STAGING",
+        "USE_LETS_ENCRYPT_WILDCARD",
+        "LETS_ENCRYPT_SERVER",
+        "LETS_ENCRYPT_CHALLENGE",
+        "GENERATE_SELF_SIGNED_SSL",
+        "USE_CUSTOM_SSL",
+        "HTTP2",
+        "HTTP3",
+        "SSL_PROTOCOLS"
+      ]
+    },
+    {
+      "title": "Reverse proxy",
+      "subtitle": "Configure the connection to the Xen Orchestra backend (HTTPS with self-signed cert and WebSocket support)",
+      "settings": [
+        "USE_REVERSE_PROXY",
+        "REVERSE_PROXY_URL",
+        "REVERSE_PROXY_HOST",
+        "REVERSE_PROXY_WS",
+        "REVERSE_PROXY_SSL_SNI",
+        "REVERSE_PROXY_KEEPALIVE",
+        "MAX_CLIENT_SIZE",
+        "ALLOWED_METHODS"
+      ]
+    },
+    {
+      "title": "Performance",
+      "subtitle": "Compression and caching settings suited for Xen Orchestra API traffic",
+      "settings": ["USE_GZIP", "GZIP_PROXIED"]
+    },
+    {
+      "title": "Rate limiting",
+      "subtitle": "Configure connection and request limits — /jsonrpc is given a higher limit to allow Xen Orchestra's API polling",
+      "settings": [
+        "LIMIT_REQ_RATE",
+        "LIMIT_REQ_URL_1",
+        "LIMIT_REQ_RATE_1",
+        "LIMIT_CONN_MAX_HTTP1",
+        "LIMIT_CONN_MAX_HTTP2",
+        "LIMIT_CONN_MAX_HTTP3"
+      ]
+    },
+    {
+      "title": "Security",
+      "subtitle": "Security settings — bad behavior detection is disabled because Xen Orchestra's API generates traffic patterns that trigger false positives",
+      "settings": [
+        "SECURITY_MODE",
+        "USE_BAD_BEHAVIOR",
+        "USE_ANTIBOT",
+        "USE_BLACKLIST",
+        "USE_DNSBL",
+        "USE_MODSECURITY",
+        "USE_MODSECURITY_CRS",
+        "KEEP_UPSTREAM_HEADERS",
+        "REFERRER_POLICY",
+        "CONTENT_SECURITY_POLICY",
+        "PERMISSIONS_POLICY",
+        "COOKIE_FLAGS",
+        "INTERCEPTED_ERROR_CODES"
+      ],
+      "configs": ["modsec/xen-orchestra_false_positives.conf"]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

- Add Xen Orchestra template with reverse proxy, WebSocket, TLS, rate limiting, and ModSecurity defaults — including a `/jsonrpc` higher rate limit and CRS exclusions for XO's API polling pattern
- Add official maintainers section to `README.md` listing [@TheophileDiot](https://github.com/TheophileDiot) and [@YouKyi](https://github.com/YouKyi)

# Testing

- [x] `jq . templates/xen-orchestra/template.json`
- [x] Validated template or docs using the listed commands
- [ ] Other (add details below)

<details>
<summary>Validation details</summary>

- `jq . templates/xen-orchestra/template.json` — passes, valid JSON
- Template manually reviewed against BunkerWeb template spec: all `configs` paths reference files present in `templates/xen-orchestra/configs/modsec/`
- Import flow documented in `templates/xen-orchestra/README.md` covers both the UI Raw mode upload and plugin bundle method
- Functional validation: dashboard login, VM console WebSocket, and live migration/snapshot actions confirmed working through BunkerWeb proxy

</details>

# Checklist

- [x] I installed the pre-commit hooks and ran `pre-commit run --all-files`.
- [x] I described the service or scenario this change targets.
- [x] `template.json` references only files shipped in the same template directory.
- [x] Template docs note how to import it (plugin bundle and/or web UI upload).
- [x] I updated configs, screenshots, or notes impacted by this change.
- [x] I linked related issues or discussions and added context for reviewers.